### PR TITLE
Introducing silent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SidekiqProcessKiller
 
-[![Build Status]( https://travis-ci.org/shayonj/sidekiq_process_killer.svg?branch=master)](https://travis-ci.org/shayonj/sidekiq_process_killer)
+[![Build Status](https://travis-ci.org/shayonj/sidekiq_process_killer.svg?branch=master)](https://travis-ci.org/shayonj/sidekiq_process_killer)
 
 When you have memory leaks or "bloats" in your ruby application, identifying and fixing them can at times be a nightmare. Instead, an _"acceptable"_ mitigation is to re-spin the workers. Its a common technique that can be found in [Puma Worker Killer](https://github.com/schneems/puma_worker_killer) or [Unicorn Worker Killer](https://github.com/kzk/unicorn-worker-killer). Though, its neater and good practice to find and fix your leaks.
 
@@ -28,6 +28,8 @@ shutdown_wait_timeout: 25 # seconds
 shutdown_signal: "SIGKILL"
 silent_mode: false
 ```
+
+`silent_mode` when set to `true` will mean that no signals for terminate or otherwise will be sent. This is helpful if you are planning to launch this, but want to first do a dry run.
 
 `memory_threshold` is the threshold, which, when, breached, the respective Sidekiq worker will be instructed for termination (via `TERM` signal, which sidekiq gracefully exits).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SidekiqProcessKiller
 
-[![Build Status](https://travis-ci.org/shayonj/sidekiq_process_killer.svg?branch=master)](https://travis-ci.org/shayonj/sidekiq_process_killer)
+[![Build Status]( https://travis-ci.org/shayonj/sidekiq_process_killer.svg?branch=master)](https://travis-ci.org/shayonj/sidekiq_process_killer)
 
 When you have memory leaks or "bloats" in your ruby application, identifying and fixing them can at times be a nightmare. Instead, an _"acceptable"_ mitigation is to re-spin the workers. Its a common technique that can be found in [Puma Worker Killer](https://github.com/schneems/puma_worker_killer) or [Unicorn Worker Killer](https://github.com/kzk/unicorn-worker-killer). Though, its neater and good practice to find and fix your leaks.
 
@@ -26,6 +26,7 @@ The default configurations are:
 memory_threshold: 250.0 # mb
 shutdown_wait_timeout: 25 # seconds
 shutdown_signal: "SIGKILL"
+silent_mode: false
 ```
 
 `memory_threshold` is the threshold, which, when, breached, the respective Sidekiq worker will be instructed for termination (via `TERM` signal, which sidekiq gracefully exits).
@@ -39,6 +40,7 @@ SidekiqProcessKiller.config do |con|
   con.memory_threshold = 1024.0
   con.shutdown_wait_timeout = 60
   con.shutdown_signal = "SIGUSR2"
+  con.silent_mode = false
 end
 ```
 

--- a/lib/sidekiq_process_killer.rb
+++ b/lib/sidekiq_process_killer.rb
@@ -1,10 +1,11 @@
 module SidekiqProcessKiller
   extend self
-  attr_accessor :memory_threshold, :shutdown_wait_timeout, :shutdown_signal
+  attr_accessor :memory_threshold, :shutdown_wait_timeout, :shutdown_signal, :silent_mode
 
   self.memory_threshold = 250.0 # mb
   self.shutdown_wait_timeout = 25 # seconds
   self.shutdown_signal = "SIGKILL"
+  self.silent_mode = false
 
   def config
     yield self

--- a/lib/sidekiq_process_killer/middleware.rb
+++ b/lib/sidekiq_process_killer/middleware.rb
@@ -32,12 +32,16 @@ module SidekiqProcessKiller
       @memory ||= GetProcessMem.new
     end
 
+    private def silent_mode_msg
+      SidekiqProcessKiller.silent_mode ? " [SILENT]" : ""
+    end
+
     private def log_warn(msg)
-      Sidekiq.logger.warn("[#{LOG_PREFIX}] #{msg}")
+      Sidekiq.logger.warn("[#{LOG_PREFIX}]#{silent_mode_msg} #{msg}")
     end
 
     private def log_info(msg)
-      Sidekiq.logger.info("[#{LOG_PREFIX}] #{msg}")
+      Sidekiq.logger.info("[#{LOG_PREFIX}]#{silent_mode_msg} #{msg}")
     end
 
     private def send_signal(name, pid)

--- a/spec/sidekiq_process_killer_spec.rb
+++ b/spec/sidekiq_process_killer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SidekiqProcessKiller do
     expect(SidekiqProcessKiller.memory_threshold).to eq(250.0)
     expect(SidekiqProcessKiller.shutdown_wait_timeout).to eq(25)
     expect(SidekiqProcessKiller.shutdown_signal).to eq("SIGKILL")
+    expect(SidekiqProcessKiller.silent_mode).to eq(false)
   end
 
   it "successfully updates the config" do
@@ -16,10 +17,12 @@ RSpec.describe SidekiqProcessKiller do
       con.memory_threshold = 1024.0
       con.shutdown_wait_timeout = 60
       con.shutdown_signal = "SIGUSR1"
+      con.silent_mode = true
     end
 
     expect(SidekiqProcessKiller.memory_threshold).to eq(1024.0)
     expect(SidekiqProcessKiller.shutdown_wait_timeout).to eq(60)
     expect(SidekiqProcessKiller.shutdown_signal).to eq("SIGUSR1")
+    expect(SidekiqProcessKiller.silent_mode).to eq(true)
   end
 end


### PR DESCRIPTION
This way, the middleware wont send any signals to kill
or terminate. Instead, just silently log.

Includes some minor refactoring unrelated to the original change, unfortunately. 