### PR TITLE
Introduce statsd_klass config options

### DIFF
--- a/lib/sidekiq_process_killer.rb
+++ b/lib/sidekiq_process_killer.rb
@@ -1,11 +1,13 @@
 module SidekiqProcessKiller
   extend self
-  attr_accessor :memory_threshold, :shutdown_wait_timeout, :shutdown_signal, :silent_mode
+
+  attr_accessor :memory_threshold, :shutdown_wait_timeout, :shutdown_signal, :silent_mode, :statsd_klass
 
   self.memory_threshold = 250.0 # mb
   self.shutdown_wait_timeout = 25 # seconds
   self.shutdown_signal = "SIGKILL"
   self.silent_mode = false
+  self.statsd_klass = nil
 
   def config
     yield self

--- a/lib/sidekiq_process_killer/middleware.rb
+++ b/lib/sidekiq_process_killer/middleware.rb
@@ -1,6 +1,7 @@
 module SidekiqProcessKiller
   class Middleware
     LOG_PREFIX = self.name
+    METRIC_PREFIX = "sidekiq_process_killer".freeze
 
     def call(worker, job, queue)
       pid = ::Process.pid
@@ -23,8 +24,20 @@ module SidekiqProcessKiller
         ::Process.getpgid(pid)
         log_warn("Forcefully killing #{pid}, with #{shutdown_signal}")
         send_signal(shutdown_signal, pid)
+
+        increment_statsd({
+          metric_name: "process.killed.forcefully",
+          worker_name: worker.class,
+          current_memory_usage: memory.mb
+        })
       rescue Errno::ESRCH
         log_warn("Process #{pid} killed successfully")
+
+        increment_statsd({
+          metric_name: "process.killed.successfully",
+          worker_name: worker.class,
+          current_memory_usage: memory.mb
+        })
       end
     end
 
@@ -48,6 +61,14 @@ module SidekiqProcessKiller
       return if SidekiqProcessKiller.silent_mode
 
       ::Process.kill(name, pid)
+    end
+
+    private def increment_statsd(params)
+      statsd_klass = SidekiqProcessKiller.statsd_klass
+      return unless statsd_klass.respond_to?(:increment)
+
+      params[:metric_name] = "#{METRIC_PREFIX}.#{params[:metric_name]}"
+      statsd_klass.increment(params)
     end
   end
 end

--- a/spec/sidekiq_process_killer_spec.rb
+++ b/spec/sidekiq_process_killer_spec.rb
@@ -10,19 +10,23 @@ RSpec.describe SidekiqProcessKiller do
     expect(SidekiqProcessKiller.shutdown_wait_timeout).to eq(25)
     expect(SidekiqProcessKiller.shutdown_signal).to eq("SIGKILL")
     expect(SidekiqProcessKiller.silent_mode).to eq(false)
+    expect(SidekiqProcessKiller.statsd_klass).to eq(nil)
   end
 
   it "successfully updates the config" do
+    object = Object.new
     SidekiqProcessKiller.config do |con|
       con.memory_threshold = 1024.0
       con.shutdown_wait_timeout = 60
       con.shutdown_signal = "SIGUSR1"
       con.silent_mode = true
+      con.statsd_klass = object
     end
 
     expect(SidekiqProcessKiller.memory_threshold).to eq(1024.0)
     expect(SidekiqProcessKiller.shutdown_wait_timeout).to eq(60)
     expect(SidekiqProcessKiller.shutdown_signal).to eq("SIGUSR1")
     expect(SidekiqProcessKiller.silent_mode).to eq(true)
+    expect(SidekiqProcessKiller.statsd_klass).to eq(object)
   end
 end


### PR DESCRIPTION
This is an optional config option, which expects the passed
in custom statsd class object to respond to `increment` function.
it then passes a `Hash` which contains, `metric_name`, `worker_name`
and `current_memory_usage`