### PR TITLE
Lock gem version and ruby version

### DIFF
--- a/sidekiq_process_killer.gemspec
+++ b/sidekiq_process_killer.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/shayonj/sidekiq_process_killer"
   spec.license       = "MIT"
 
+  spec.required_ruby_version  = ">= 2.2.2"
+
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
@@ -23,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "get_process_mem"
-  spec.add_dependency "sidekiq"
+  spec.add_dependency "get_process_mem", "~> 0.2.1"
+  spec.add_dependency "sidekiq", "~> 5.0.5"
 end


### PR DESCRIPTION
Locking ruby version to the same as sidekiq.