### PR TITLE
Rename silent_mode to dry_run and add deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ The default configurations are:
 memory_threshold: 250.0 # mb
 shutdown_wait_timeout: 25 # seconds
 shutdown_signal: "SIGKILL"
-silent_mode: false
+dry_run: false
 statsd_klass: nil
 ```
 
-- `silent_mode`: When set to `true`, it will mean that no signals for terminate or otherwise will be sent. This is helpful if you are planning to launch this, but want to first do a dry run.
+- `dry_run`: When set to `true`, it will mean that no signals for terminate or otherwise will be sent. This is helpful if you are planning to launch this, but want to first do a dry run.
 - `memory_threshold`: This is the threshold, which, when, breached, the respective Sidekiq worker will be instructed for termination (via `TERM` signal, which sidekiq gracefully exits).
 - `shutdown_signal`: Signal for force shutdown/kill/quit.
 - `shutdown_wait_timeout`: If, for some reason, the process takes more than the timeout defined in `shutdown_wait_timeout`, to die, the process will be forced terminated using the signal set in `shutdown_signal`.
@@ -59,7 +59,7 @@ SidekiqProcessKiller.config do |con|
   con.memory_threshold = 1024.0
   con.shutdown_wait_timeout = 60
   con.shutdown_signal = "SIGUSR2"
-  con.silent_mode = false
+  con.dry_run = false
   con.statsd_klass = CustomMetric.new # your custom statsd class object
 end
 ```

--- a/lib/sidekiq_process_killer.rb
+++ b/lib/sidekiq_process_killer.rb
@@ -1,11 +1,12 @@
 module SidekiqProcessKiller
   extend self
 
-  attr_accessor :memory_threshold, :shutdown_wait_timeout, :shutdown_signal, :silent_mode, :statsd_klass
+  attr_accessor :memory_threshold, :shutdown_wait_timeout, :shutdown_signal, :silent_mode, :dry_run, :statsd_klass
 
   self.memory_threshold = 250.0 # mb
   self.shutdown_wait_timeout = 25 # seconds
   self.shutdown_signal = "SIGKILL"
+  self.dry_run = false
   self.silent_mode = false
   self.statsd_klass = nil
 

--- a/lib/sidekiq_process_killer/middleware.rb
+++ b/lib/sidekiq_process_killer/middleware.rb
@@ -58,20 +58,21 @@ module SidekiqProcessKiller
       end.join(", ")
     end
 
-    private def silent_mode_msg
-      SidekiqProcessKiller.silent_mode ? " [SILENT]" : ""
+    private def dry_run_msg
+      SidekiqProcessKiller.dry_run ? " [DRY RUN]" : ""
     end
 
     private def log_warn(msg)
-      Sidekiq.logger.warn("[#{LOG_PREFIX}]#{silent_mode_msg} #{msg} #{humanized_attributes}")
+      Sidekiq.logger.warn("[#{LOG_PREFIX}]#{dry_run_msg} #{msg} #{humanized_attributes}")
     end
 
     private def log_info(msg)
-      Sidekiq.logger.info("[#{LOG_PREFIX}]#{silent_mode_msg} #{msg} #{humanized_attributes}")
+      Sidekiq.logger.info("[#{LOG_PREFIX}]#{dry_run_msg} #{msg} #{humanized_attributes}")
     end
 
     private def send_signal(name, pid)
-      return if SidekiqProcessKiller.silent_mode
+      log_warn("DEPRECATION: silent_mode config option will be deprecated. Please use dry_run instead.") if SidekiqProcessKiller.silent_mode
+      return if SidekiqProcessKiller.dry_run || SidekiqProcessKiller.silent_mode
 
       ::Process.kill(name, pid)
     end

--- a/spec/lib/sidekiq_process_killer/middleware_spec.rb
+++ b/spec/lib/sidekiq_process_killer/middleware_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SidekiqProcessKiller::Middleware do
     SidekiqProcessKiller.config do |con|
       con.memory_threshold = 250.0
       con.shutdown_wait_timeout = 25
-      con.silent_mode = false
+      con.dry_run = false
       con.shutdown_signal = "SIGKILL"
       con.statsd_klass = nil
     end
@@ -110,10 +110,10 @@ RSpec.describe SidekiqProcessKiller::Middleware do
     end
   end
 
-  it "does not need any signal when silent mode is on" do
+  it "does not need any signal when dry run mode is on" do
     SidekiqProcessKiller.config do |con|
       con.shutdown_wait_timeout = 1
-      con.silent_mode = true
+      con.dry_run = true
     end
 
     expect(::Process).to_not receive(:kill)

--- a/spec/sidekiq_process_killer_spec.rb
+++ b/spec/sidekiq_process_killer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SidekiqProcessKiller do
     expect(SidekiqProcessKiller.memory_threshold).to eq(250.0)
     expect(SidekiqProcessKiller.shutdown_wait_timeout).to eq(25)
     expect(SidekiqProcessKiller.shutdown_signal).to eq("SIGKILL")
-    expect(SidekiqProcessKiller.silent_mode).to eq(false)
+    expect(SidekiqProcessKiller.dry_run).to eq(false)
     expect(SidekiqProcessKiller.statsd_klass).to eq(nil)
   end
 
@@ -19,14 +19,14 @@ RSpec.describe SidekiqProcessKiller do
       con.memory_threshold = 1024.0
       con.shutdown_wait_timeout = 60
       con.shutdown_signal = "SIGUSR1"
-      con.silent_mode = true
+      con.dry_run = true
       con.statsd_klass = object
     end
 
     expect(SidekiqProcessKiller.memory_threshold).to eq(1024.0)
     expect(SidekiqProcessKiller.shutdown_wait_timeout).to eq(60)
     expect(SidekiqProcessKiller.shutdown_signal).to eq("SIGUSR1")
-    expect(SidekiqProcessKiller.silent_mode).to eq(true)
+    expect(SidekiqProcessKiller.dry_run).to eq(true)
     expect(SidekiqProcessKiller.statsd_klass).to eq(object)
   end
 end


### PR DESCRIPTION
`silent_mode` name can appear to be confusing. The main task is here to not send any signals to the process, ideally, to be used in a "dry run" mode.