### PR TITLE
Disable the ability to forcefully kill sidekiq process

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 When you have memory leaks or "bloats" in your ruby application, identifying and fixing them can at times be a nightmare. Instead, an _"acceptable"_ mitigation is to re-spin the workers. Its a common technique that can be found in [Puma Worker Killer](https://github.com/schneems/puma_worker_killer) or [Unicorn Worker Killer](https://github.com/kzk/unicorn-worker-killer). Though, its neater and good practice to find and fix your leaks.
 
-SidekiqProcessKiller plugs into Sidekiq's middleware and kills a process if its processing beyond the supplied [RSS](https://en.wikipedia.org/wiki/Resident_set_size) threshold. Since this plugs into the middleware, the check is performed after each job.
+SidekiqProcessKiller plugs into Sidekiq's middleware and kills a process (by sending `SIGTERM`) if its processing beyond the supplied [RSS](https://en.wikipedia.org/wiki/Resident_set_size) threshold. Since this plugs into the middleware, the check is performed after each job.
 
 ## Installation
 
@@ -20,12 +20,9 @@ Add the following to your Gemfile
 
 ### Configuration
 
-The default configurations are:
 
 ```ruby
 memory_threshold: 250.0 # mb
-shutdown_wait_timeout: 25 # seconds
-shutdown_signal: "SIGKILL"
 silent_mode: false
 statsd_klass: nil
 ```
@@ -36,8 +33,6 @@ statsd_klass: nil
 |-------------------------	|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
 | `silent_mode`           	| When set to `true`, no signal will be sent to running process. This is helpful if you are planning to launch this, but want to first do a dry run.
 | `memory_threshold`      	| When current RSS is above this threshold, the respective Sidekiq worker will be instructed for termination (via `TERM` signal, which sidekiq gracefully exits).                                                                                                                                                                                                                                                                                                                                                                                                              	|
-| `shutdown_signal`       	| Signal for force shutdown/kill/quit.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             	|
-| `shutdown_wait_timeout` 	| If the process takes more than the timeout defined in `shutdown_wait_timeout`, the process will be forced terminated using the signal set in mentioned in `shutdown_signal`.                                                                                                                                                                                                                                                                                                                                                                                                        	|
 | `statsd_klass`          	| This is a class object which responds to an `increment`. If present, the `increment` function will be called with a single argument of type `Hash` which contains, `metric_name`, `worker_name` and `current_memory_usage`. This class is called when attempting to terminate a process or if the process had to be forcefully be terminated.	|
 
 
@@ -61,8 +56,6 @@ end
 
 SidekiqProcessKiller.config do |con|
   con.memory_threshold = 1024.0
-  con.shutdown_wait_timeout = 60
-  con.shutdown_signal = "SIGUSR2"
   con.silent_mode = false
   con.statsd_klass = CustomMetric.new # your custom statsd class object
 end

--- a/lib/sidekiq_process_killer.rb
+++ b/lib/sidekiq_process_killer.rb
@@ -1,10 +1,8 @@
 module SidekiqProcessKiller
   extend self
 
-  attr_accessor :shutdown_wait_timeout, :shutdown_signal, :silent_mode, :statsd_klass
+  attr_accessor :silent_mode, :statsd_klass
 
-  self.shutdown_wait_timeout = 25 # seconds
-  self.shutdown_signal = "SIGKILL"
   self.silent_mode = false
   self.statsd_klass = nil
 

--- a/spec/sidekiq_process_killer_spec.rb
+++ b/spec/sidekiq_process_killer_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe SidekiqProcessKiller do
 
   it "has the default config" do
     expect(SidekiqProcessKiller.memory_threshold).to eq(250.0)
-    expect(SidekiqProcessKiller.shutdown_wait_timeout).to eq(25)
-    expect(SidekiqProcessKiller.shutdown_signal).to eq("SIGKILL")
     expect(SidekiqProcessKiller.silent_mode).to eq(false)
     expect(SidekiqProcessKiller.statsd_klass).to eq(nil)
   end
@@ -17,15 +15,11 @@ RSpec.describe SidekiqProcessKiller do
     object = Object.new
     SidekiqProcessKiller.config do |con|
       con.memory_threshold = 1024.0
-      con.shutdown_wait_timeout = 60
-      con.shutdown_signal = "SIGUSR1"
       con.silent_mode = true
       con.statsd_klass = object
     end
 
     expect(SidekiqProcessKiller.memory_threshold).to eq(1024.0)
-    expect(SidekiqProcessKiller.shutdown_wait_timeout).to eq(60)
-    expect(SidekiqProcessKiller.shutdown_signal).to eq("SIGUSR1")
     expect(SidekiqProcessKiller.silent_mode).to eq(true)
     expect(SidekiqProcessKiller.statsd_klass).to eq(object)
   end


### PR DESCRIPTION
Sidekiq supports `TERM` signal, such that, when received one,
it gracefully attempts to pause the workers, and shutsdown.

Hence, killing a process manually here, can be destructive, as
we are not allowing sidekiq to fullfil the worker completion cycle.
Which can also lead to unexpected behaviors of leaving jobs/batches
in private queues.

Moving forward, there won't be any `shutdown_signal` and
`shutdown_wait_timeout` config options. When a `TERM` signal is
received, sidekiq attempts to wait for the default `timeout` (`-t`)
period supplied at the time of sidekiq process boot. If a process,
does not terminate within the timeout period, its forcefully terminated.

Lastly, because the behavior is changing, so is the name of the custom metrics.